### PR TITLE
add id_set option in _temporal_corr

### DIFF
--- a/q2_longitudinal/_utilities.py
+++ b/q2_longitudinal/_utilities.py
@@ -580,21 +580,23 @@ def _stats_and_visuals(output_dir, pairs, metric, group_column,
                pairwise_test_name=pairwise_test_name)
 
 
-def _temporal_corr(table, individual_id, corr_method="kendall"):
+def _temporal_corr(table, individual_id, id_set, corr_method="kendall"):
     '''Create Temporal correlation from a feature table containing repeated
     measures samples.
     table: pd.DataFrame
         rows are samples, columns are features (count / relative_abundance)
     individual_id: pd.Series
         subject id of samples, with the same length as df
+    id_set: pd.Series
+        unique subject ids from individual_id with index attached
     corr_method: str
         temporal correlation method, "kendall", "pearson", "spearman"
 
     '''
     results = {}
-
+      
     # Start to calculate temporal correlation
-    for id_key in individual_id.unique():
+    for id_key in id_set:
         table_id = table.loc[individual_id == id_key]
         results[id_key] = table_id.corr(method=corr_method).fillna(0)
 
@@ -641,7 +643,7 @@ def _nmit(taxa, sample_md, individual_id_column, corr_method="kendall",
     individual_id = sample_md[individual_id_column]
 
     # calculate species correlation in individuals
-    _corr = _temporal_corr(taxa, individual_id,  corr_method)
+    _corr = _temporal_corr(taxa, individual_id, id_set,  corr_method)
 
     # calculate distance between individuals
     _dist = _temporal_distance(_corr, id_set, dist_method)


### PR DESCRIPTION
The id_set is required to make sure the order of the correlation keep the same while calculate the distance matrix.